### PR TITLE
[WIP] port: build for macOS

### DIFF
--- a/cuda-matmul/CMakeLists.txt
+++ b/cuda-matmul/CMakeLists.txt
@@ -3,4 +3,11 @@ project(matmul)
 
 set(CMAKE_CXX_STANDARD 17)
 
-add_executable(sequential sequential.cpp) 
+add_executable(sequential sequential.cpp)
+
+add_executable(tiling sequential.cpp)
+target_compile_definitions(tiling PRIVATE TILING)
+
+add_executable(slow sequential.cpp)
+target_compile_definitions(slow PRIVATE SLOW)
+

--- a/cuda-matmul/CMakeLists.txt
+++ b/cuda-matmul/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 3.24)
+project(matmul)
+
+set(CMAKE_CXX_STANDARD 17)
+
+add_executable(sequential sequential.cpp) 

--- a/cuda-matmul/matrix.hpp
+++ b/cuda-matmul/matrix.hpp
@@ -3,7 +3,21 @@
 #include <sstream>
 #include <stdexcept>
 #include <vector>
+
+#if defined(__x86_64__) || defined(_M_X64)
 #include <xmmintrin.h>
+#else
+#include <cstdlib>
+static inline void *_emulate_mm_malloc(size_t size, size_t align) {
+  void *ptr = nullptr;
+  if (posix_memalign(&ptr, align, size) != 0) {
+    throw std::bad_alloc();
+  }
+  return ptr;
+}
+#define _mm_malloc _emulate_mm_malloc
+#define _mm_free free
+#endif 
 
 template <typename T> class AlignedAllocator {
 public:

--- a/cuda-matmul/matrix.hpp
+++ b/cuda-matmul/matrix.hpp
@@ -1,23 +1,8 @@
-#include <fstream>
-#include <iostream>
-#include <sstream>
-#include <stdexcept>
-#include <vector>
+#ifndef MATRIX_HPP
+#define MATRIX_HPP
+#include "platform.h"
 
-#if defined(__x86_64__) || defined(_M_X64)
-#include <xmmintrin.h>
-#else
-#include <cstdlib>
-static inline void *_emulate_mm_malloc(size_t size, size_t align) {
-  void *ptr = nullptr;
-  if (posix_memalign(&ptr, align, size) != 0) {
-    throw std::bad_alloc();
-  }
-  return ptr;
-}
-#define _mm_malloc _emulate_mm_malloc
-#define _mm_free free
-#endif 
+#pragma once
 
 template <typename T> class AlignedAllocator {
 public:
@@ -40,6 +25,14 @@ public:
   }
 
   void deallocate(pointer p, size_type) { _mm_free(p); }
+
+  bool operator==(const AlignedAllocator &) const { 
+    return true; 
+  }
+
+  bool operator!=(const AlignedAllocator &other) const {
+    return !(*this == other);
+  }
 };
 
 template <typename T> class Matrix {
@@ -121,3 +114,5 @@ public:
     }
   }
 };
+
+#endif // MATRIX_HPP

--- a/cuda-matmul/platform.h
+++ b/cuda-matmul/platform.h
@@ -1,0 +1,30 @@
+#ifndef PLATFORM_H
+#define PLATFORM_H
+
+#ifndef __cplusplus
+#error A C++ compiler is required!
+#endif
+
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+#include <vector>
+
+#if defined(__x86_64__) || defined(_M_X64)
+#include <xmmintrin.h>
+#include <immintrin.h>
+#else
+#include <cstdlib>
+static inline void *_emulate_mm_malloc(size_t size, size_t align) {
+  void *ptr = nullptr;
+  if (posix_memalign(&ptr, align, size) != 0) {
+    throw std::bad_alloc();
+  }
+  return ptr;
+}
+#define _mm_malloc _emulate_mm_malloc
+#define _mm_free free
+#endif 
+
+#endif // PLATFORM_H

--- a/cuda-matmul/sequential.cpp
+++ b/cuda-matmul/sequential.cpp
@@ -1,9 +1,13 @@
-#include "matrix.cpp"
 #include <chrono>
+
+#if defined(__x86_64__) || defined(_M_X64)
 #include <immintrin.h>
+#endif 
+
 #include <iostream>
 #include <numeric>
 #include <stdint.h>
+#include "matrix.hpp"
 
 using data_type = double;
 

--- a/cuda-matmul/sequential.cpp
+++ b/cuda-matmul/sequential.cpp
@@ -1,12 +1,8 @@
 #include <chrono>
-
-#if defined(__x86_64__) || defined(_M_X64)
-#include <immintrin.h>
-#endif 
-
 #include <iostream>
 #include <numeric>
-#include <stdint.h>
+#include <cstdint>
+
 #include "matrix.hpp"
 
 using data_type = double;


### PR DESCRIPTION
Hello @mustafasegf 

⚠️ This is not a working code, this PR is for reviewing and discussion only.

I tried to port your code and Makefiles to CMake and found out some oddities

- You include a `.cpp` files, if it's a template, you can just include a `header` files and do not need to make it a "library" because it won't produce any code. Therefore I renamed `matrix.cpp` to `matrix.hpp`
- The `_mm_malloc` doesn't exist on macOS, I ported to `posix_memalign` and put a bunch of IFDEFS in intel intrinsics.
- I tried to compile on macOS but found out this error.

```
[1/2] Building CXX object CMakeFiles/sequential.dir/sequential.cpp.o
FAILED: CMakeFiles/sequential.dir/sequential.cpp.o 
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++   -std=gnu++17 -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.4.sdk -MD -MT CMakeFiles/sequential.dir/sequential.cpp.o -MF CMakeFiles/sequential.dir/sequential.cpp.o.d -o CMakeFiles/sequential.dir/sequential.cpp.o -c /Users/lynxluna/Projects/parallel-prog/cuda-matmul/sequential.cpp
In file included from /Users/lynxluna/Projects/parallel-prog/cuda-matmul/sequential.cpp:8:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.4.sdk/usr/include/c++/v1/numeric:174:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.4.sdk/usr/include/c++/v1/functional:526:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.4.sdk/usr/include/c++/v1/__functional/boyer_moore_searcher.h:27:
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.4.sdk/usr/include/c++/v1/vector:1380:19: error: invalid operands to binary expression ('allocator_type' (aka 'AlignedAllocator<double>') and 'allocator_type')
    if (__alloc() != __c.__alloc())
        ~~~~~~~~~ ^  ~~~~~~~~~~~~~
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.4.sdk/usr/include/c++/v1/vector:1369:5: note: in instantiation of member function 'std::vector<double, AlignedAllocator<double>>::__move_assign' requested here
    __move_assign(__x, integral_constant<bool,
    ^
/Users/lynxluna/Projects/parallel-prog/cuda-matmul/matrix.hpp:87:10: note: in instantiation of member function 'std::vector<double, AlignedAllocator<double>>::operator=' requested here
    data = std::vector<T, AlignedAllocator<T>>(loadedData.begin(),
         ^
/Users/lynxluna/Projects/parallel-prog/cuda-matmul/sequential.cpp:22:23: note: in instantiation of member function 'Matrix<double>::Matrix' requested here
    Matrix<data_type> matrix1(argv[1]);
                      ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.4.sdk/usr/include/c++/v1/__variant/monostate.h:38:38: note: candidate function not viable: no known conversion from 'allocator_type' (aka 'AlignedAllocator<double>') to 'monostate' for 1st argument
_LIBCPP_HIDE_FROM_ABI constexpr bool operator!=(monostate, monostate) noexcept { return false; }
                                     ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.4.sdk/usr/include/c++/v1/__system_error/error_condition.h:104:35: note: candidate function not viable: no known conversion from 'allocator_type' (aka 'AlignedAllocator<double>') to 'const error_condition' for 1st argument
inline _LIBCPP_HIDE_FROM_ABI bool operator!=(const error_condition& __x, const error_condition& __y) _NOEXCEPT {
                                  ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.4.sdk/usr/include/c++/v1/__system_error/error_code.h:110:35: note: candidate function not viable: no known conversion from 'allocator_type' (aka 'AlignedAllocator<double>') to 'const error_code' for 1st argument
inline _LIBCPP_HIDE_FROM_ABI bool operator!=(const error_code& __x, const error_code& __y) _NOEXCEPT {
                                  ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.4.sdk/usr/include/c++/v1/__system_error/error_code.h:114:35: note: candidate function not viable: no known conversion from 'allocator_type' (aka 'AlignedAllocator<double>') to 'const error_code' for 1st argument
inline _LIBCPP_HIDE_FROM_ABI bool operator!=(const error_code& __x, const error_condition& __y) _NOEXCEPT {
                                  ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.4.sdk/usr/include/c++/v1/__system_error/error_code.h:118:35: note: candidate function not viable: no known conversion from 'allocator_type' (aka 'AlignedAllocator<double>') to 'const error_condition' for 1st argument
inline _LIBCPP_HIDE_FROM_ABI bool operator!=(const error_condition& __x, const error_code& __y) _NOEXCEPT {
                                  ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.4.sdk/usr/include/c++/v1/__thread/id.h:89:35: note: candidate function not viable: no known conversion from 'allocator_type' (aka 'AlignedAllocator<double>') to '__thread_id' for 1st argument
inline _LIBCPP_HIDE_FROM_ABI bool operator!=(__thread_id __x, __thread_id __y) _NOEXCEPT { return !(__x == __y); }
                                  ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.4.sdk/usr/include/c++/v1/__utility/pair.h:636:1: note: candidate template ignored: could not match 'pair' against 'AlignedAllocator'
operator!=(const pair<_T1,_T2>& __x, const pair<_U1,_U2>& __y)
^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.4.sdk/usr/include/c++/v1/__iterator/reverse_iterator.h:235:1: note: candidate template ignored: could not match 'reverse_iterator' against 'AlignedAllocator'
operator!=(const reverse_iterator<_Iter1>& __x, const reverse_iterator<_Iter2>& __y)
^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.4.sdk/usr/include/c++/v1/string_view:849:6: note: candidate template ignored: could not match 'basic_string_view' against 'AlignedAllocator'
bool operator!=(basic_string_view<_CharT, _Traits> __lhs, basic_string_view<_CharT, _Traits> __rhs) _NOEXCEPT
     ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.4.sdk/usr/include/c++/v1/string_view:858:6: note: candidate template ignored: could not match 'basic_string_view' against 'AlignedAllocator'
bool operator!=(basic_string_view<_CharT, _Traits> __lhs,
     ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.4.sdk/usr/include/c++/v1/string_view:868:6: note: candidate template ignored: could not match 'basic_string_view' against 'AlignedAllocator'
bool operator!=(__type_identity_t<basic_string_view<_CharT, _Traits> > __lhs,
     ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.4.sdk/usr/include/c++/v1/__memory/unique_ptr.h:532:1: note: candidate template ignored: could not match 'unique_ptr' against 'AlignedAllocator'
operator!=(const unique_ptr<_T1, _D1>& __x, const unique_ptr<_T2, _D2>& __y) {return !(__x == __y);}
^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.4.sdk/usr/include/c++/v1/__memory/unique_ptr.h:592:1: note: candidate template ignored: could not match 'unique_ptr' against 'AlignedAllocator'
operator!=(const unique_ptr<_T1, _D1>& __x, nullptr_t) _NOEXCEPT
^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.4.sdk/usr/include/c++/v1/__memory/unique_ptr.h:600:1: note: candidate template ignored: could not match 'unique_ptr' against 'AlignedAllocator'
operator!=(nullptr_t, const unique_ptr<_T1, _D1>& __x) _NOEXCEPT
^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.4.sdk/usr/include/c++/v1/__iterator/move_iterator.h:263:6: note: candidate template ignored: could not match 'move_iterator' against 'AlignedAllocator'
bool operator!=(const move_iterator<_Iter1>& __x, const move_iterator<_Iter2>& __y)
     ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.4.sdk/usr/include/c++/v1/__memory/allocator.h:269:6: note: candidate template ignored: could not match 'allocator' against 'AlignedAllocator'
bool operator!=(const allocator<_Tp>&, const allocator<_Up>&) _NOEXCEPT {return false;}
     ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.4.sdk/usr/include/c++/v1/__iterator/wrap_iter.h:137:6: note: candidate template ignored: could not match '__wrap_iter' against 'AlignedAllocator'
bool operator!=(const __wrap_iter<_Iter1>& __x, const __wrap_iter<_Iter1>& __y) _NOEXCEPT
     ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.4.sdk/usr/include/c++/v1/__iterator/wrap_iter.h:144:6: note: candidate template ignored: could not match '__wrap_iter' against 'AlignedAllocator'
bool operator!=(const __wrap_iter<_Iter1>& __x, const __wrap_iter<_Iter2>& __y) _NOEXCEPT
     ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.4.sdk/usr/include/c++/v1/tuple:1597:1: note: candidate template ignored: could not match 'tuple' against 'AlignedAllocator'
operator!=(const tuple<_Tp...>& __x, const tuple<_Up...>& __y)
^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.4.sdk/usr/include/c++/v1/variant:1682:16: note: candidate template ignored: could not match 'variant' against 'AlignedAllocator'
constexpr bool operator!=(const variant<_Types...>& __lhs,
               ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.4.sdk/usr/include/c++/v1/__iterator/istream_iterator.h:96:1: note: candidate template ignored: could not match 'istream_iterator' against 'AlignedAllocator'
operator!=(const istream_iterator<_Tp, _CharT, _Traits, _Distance>& __x,
^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.4.sdk/usr/include/c++/v1/__iterator/istreambuf_iterator.h:112:6: note: candidate template ignored: could not match 'istreambuf_iterator' against 'AlignedAllocator'
bool operator!=(const istreambuf_iterator<_CharT,_Traits>& __a,
     ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.4.sdk/usr/include/c++/v1/__memory/shared_ptr.h:1355:1: note: candidate template ignored: could not match 'shared_ptr' against 'AlignedAllocator'
operator!=(const shared_ptr<_Tp>& __x, const shared_ptr<_Up>& __y) _NOEXCEPT
^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.4.sdk/usr/include/c++/v1/__memory/shared_ptr.h:1430:1: note: candidate template ignored: could not match 'shared_ptr' against 'AlignedAllocator'
operator!=(const shared_ptr<_Tp>& __x, nullptr_t) _NOEXCEPT
^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.4.sdk/usr/include/c++/v1/__memory/shared_ptr.h:1438:1: note: candidate template ignored: could not match 'shared_ptr' against 'AlignedAllocator'
operator!=(nullptr_t, const shared_ptr<_Tp>& __x) _NOEXCEPT
^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.4.sdk/usr/include/c++/v1/__ios/fpos.h:73:6: note: candidate template ignored: could not match 'fpos' against 'AlignedAllocator'
bool operator!=(const fpos<_StateT>& __x, const fpos<_StateT>& __y) {
     ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.4.sdk/usr/include/c++/v1/string:3962:1: note: candidate template ignored: could not match 'basic_string' against 'AlignedAllocator'
operator!=(const basic_string<_CharT,_Traits,_Allocator>& __lhs,
^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.4.sdk/usr/include/c++/v1/string:3971:1: note: candidate template ignored: could not match 'const _CharT *' against 'allocator_type' (aka 'AlignedAllocator<double>')
operator!=(const _CharT* __lhs,
^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.4.sdk/usr/include/c++/v1/string:3980:1: note: candidate template ignored: could not match 'basic_string' against 'AlignedAllocator'
operator!=(const basic_string<_CharT, _Traits, _Allocator>& __lhs,
^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.4.sdk/usr/include/c++/v1/array:412:35: note: candidate template ignored: could not match 'array' against 'AlignedAllocator'
inline _LIBCPP_HIDE_FROM_ABI bool operator!=(const array<_Tp, _Size>& __x, const array<_Tp, _Size>& __y) {
                                  ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.4.sdk/usr/include/c++/v1/optional:1273:1: note: candidate template ignored: could not match 'optional' against 'AlignedAllocator'
operator!=(const optional<_Tp>& __x, const optional<_Up>& __y)
^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.4.sdk/usr/include/c++/v1/optional:1380:1: note: candidate template ignored: could not match 'optional' against 'AlignedAllocator'
operator!=(const optional<_Tp>& __x, nullopt_t) noexcept
^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.4.sdk/usr/include/c++/v1/optional:1388:1: note: candidate template ignored: could not match 'optional' against 'AlignedAllocator'
operator!=(nullopt_t, const optional<_Tp>& __x) noexcept
^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.4.sdk/usr/include/c++/v1/optional:1498:1: note: candidate template ignored: could not match 'optional' against 'AlignedAllocator'
operator!=(const optional<_Tp>& __x, const _Up& __v)
^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.4.sdk/usr/include/c++/v1/optional:1510:1: note: candidate template ignored: could not match 'optional' against 'AlignedAllocator'
operator!=(const _Tp& __v, const optional<_Up>& __x)
^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.4.sdk/usr/include/c++/v1/unordered_map:2010:1: note: candidate template ignored: could not match 'unordered_map' against 'AlignedAllocator'
operator!=(const unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.4.sdk/usr/include/c++/v1/unordered_map:2772:1: note: candidate template ignored: could not match 'unordered_multimap' against 'AlignedAllocator'
operator!=(const unordered_multimap<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
^
1 error generated.
ninja: build stopped: subcommand failed.
```

Which means that the former problem with the type of the allocator still exits. 

# How I build it

- Install cmake and ninja.
- Use this command

```bash
mkdir -p .build
cmake -G Ninja ..
ninja
```

Can you check whether this runs on Linux?
